### PR TITLE
Add custom settings feature

### DIFF
--- a/Apply-Settings.ps1
+++ b/Apply-Settings.ps1
@@ -1,0 +1,147 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string]
+    $NoitaExecutable
+)
+
+$InformationPreference = "Continue"
+
+Write-Information "
+This script prepares your Noita game environment for a Noita map capture. For an optimised map capture experience the Noita development build (noita_dev.exe) is used. The dev build uses a different savegame and config and the release build (noita.exe). Any changes done by this script should only apply to a game started with noita_dev.exe. Your normal configuration and savegames should remain untouched.
+
+The followign actions will be performed:
+  1. Reset dev build game configuration.
+  2. Apply default settings to dev build game configuration.
+  3. Apply custom settings to dev build game configuration.
+  4. Enable noita-mapcap mod.
+
+"
+Write-Warning "Use this script at your own risk. Backup important data."
+
+$yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes"
+$no = New-Object System.Management.Automation.Host.ChoiceDescription "&No"
+$options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
+$choice = $host.ui.PromptForChoice("Do you want to continue?", $null, $options, 0)
+""
+switch ($choice) {
+    1 { exit }
+}
+
+#region Find noita_dev.exe
+Write-Verbose "Looking for Noita game directory and executable."
+
+if ($NoitaExecutable) {
+    $noitaExe = Get-Item $NoitaExecutable -ErrorAction Stop
+    if ($noitaExe.Name -ne "noita_dev.exe") {
+        Write-Error "Executable is not noita_dev.exe!" -ErrorAction Stop
+    }
+} else {
+    if (Test-Path (Join-Path $PSScriptRoot ..\..\noita_dev.exe)) {
+        $noitaExe = Get-Item (Join-Path $PSScriptRoot ..\..\noita_dev.exe) -ErrorAction Stop
+    } else {
+        Write-Error "noita_dev.exe not found!" -ErrorAction Stop
+    }
+}
+#endregion
+
+
+#region Reset dev build game configuration
+Write-Verbose "Resetting game config for noita_dev.exe."
+
+# The next lines would be easier with Start-Process, but I was not able to hide the stdOut of noita_dev.exe this way.
+# $p = Start-Process $noitaExe -ArgumentList "-clean_config" -WorkingDirectory $noitaExe.Directory -PassThru -NoNewWindow
+$psi = New-object System.Diagnostics.ProcessStartInfo
+$psi.CreateNoWindow = $true
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.FileName = $noitaExe
+$psi.WorkingDirectory = $noitaExe.Directory
+$psi.Arguments = @("-clean_config")
+$p = New-Object System.Diagnostics.Process
+$p.StartInfo = $psi
+[void]$p.Start()
+
+$job = Start-Job -ArgumentList $p.Id -ScriptBlock {
+    $procId = $args[0]
+        (1..10) | ForEach-Object {
+        Start-Sleep 1
+        taskkill /PID $procId # *> $null
+    }
+    if (Get-Process -Id $procId) {
+        Write-Warning "Unable to automatically close noita_dev.exe. Please close the game window manually."
+    }
+}
+
+$p.WaitForExit()
+Stop-Job $job
+Remove-Job $job
+
+if (Test-Path "$($NoitaExecutable.Directory)\save_shared\config.xml") {
+    Write-Host "Successfully reset config.xml" -ForegroundColor Green
+}
+#endregion
+
+#region Apply optimised and custom settings
+# Get settings
+$defaultSettingsPath = (Join-Path $PSScriptRoot "settings.default.jsonc")
+$customSettingsPath = (Join-Path $PSScriptRoot "settings.jsonc")
+If (Test-Path $defaultSettingsPath) {
+    $defaultSettings = Get-Content $defaultSettingsPath | ConvertFrom-Json -AsHashtable
+} else {
+    Write-Error "Default settings file '$($defaultSettingsPath.Name)' not found!"
+}
+If (Test-Path $customSettingsPath) {
+    $customSettings = Get-Content $customSettingsPath | ConvertFrom-Json -AsHashtable
+}
+
+# Merge custom settings into recommended settings, overriding the latter.
+$mergedSettings = $defaultSettings.Clone()
+if ($customSettings) {
+    $customSettings.general_settings.GetEnumerator() | ForEach-Object { $mergedSettings.general_settings[$_.Key] = $_.Value }
+    $customSettings.config_xml.GetEnumerator() | ForEach-Object { $mergedSettings.general_settings[$_.Key] = $_.Value }
+}
+
+$mergedSettings.config_xml.window_w = $mergedSettings.general_settings.CAPTURE_RESOLUTION_WIDTH
+$mergedSettings.config_xml.window_h = $mergedSettings.general_settings.CAPTURE_RESOLUTION_HEIGHT
+$mergedSettings.config_xml.internal_size_w = $mergedSettings.general_settings.CAPTURE_RESOLUTION_WIDTH
+$mergedSettings.config_xml.internal_size_h = $mergedSettings.general_settings.CAPTURE_RESOLUTION_HEIGHT
+$mergedSettings.config_xml.backbuffer_width = $mergedSettings.general_settings.CAPTURE_RESOLUTION_WIDTH
+$mergedSettings.config_xml.backbuffer_height = $mergedSettings.general_settings.CAPTURE_RESOLUTION_HEIGHT
+
+# Apply settings to config.xml
+$configFile = Get-Item (Join-Path $noitaExe.Directory "save_shared\config.xml")
+$config = [Xml](Get-Content $configFile)
+$mergedSettings.config_xml.GetEnumerator() | ForEach-Object {
+    $config.Config."$($_.Key)" = $_.Value
+}
+$config.Save($configFile)
+
+# Apply settings to magic_numbers.xml
+$modMagicNumbersFile = Get-Item (Join-Path $PSScriptRoot "files\magic_numbers.xml")
+$modMagicNumbers = [Xml](Get-Content $modMagicNumbersFile)
+$modMagicNumbers.MagicNumbers.VIRTUAL_RESOLUTION_X = $mergedSettings.general_settings.CAPTURE_RESOLUTION_WIDTH
+$modMagicNumbers.MagicNumbers.VIRTUAL_RESOLUTION_Y = $mergedSettings.general_settings.CAPTURE_RESOLUTION_HEIGHT
+if ($mergedSettings.general_settings.WORLD_SEED) {
+    $modMagicNumbers.MagicNumbers.SetAttribute("WORLD_SEED", $mergedSettings.general_settings.WORLD_SEED)
+}
+$modMagicNumbers.Save($modMagicNumbersFile)
+
+if ($customSettings) {
+    Write-Host "Successfully applied CUSTOM settings (settings.jsonc) to dev config." -ForegroundColor Green
+} else {
+    Write-Host "Successfully applied default settings (settings.default.jsonc) to dev config." -ForegroundColor Green
+}
+
+# Enable Mod
+$noitaModConfigFile = Get-Item (Join-Path $noitaExe.Directory "save00\mod_config.xml")
+$noitaModConfig = [Xml](Get-Content $noitaModConfigFile)
+$node = $noitaModConfig.Mods.Mod | Where-Object name -eq "noita-mapcap"
+$node.enabled = 1
+$noitaModConfig.Save($noitaModConfigFile)
+#endregion
+
+Write-Host "Successfully enabled noita-mapcap mod." -ForegroundColor Green
+
+Write-Host "All done! " -ForegroundColor Green -NoNewline

--- a/README.md
+++ b/README.md
@@ -20,24 +20,26 @@ A resulting image with nearly 3.8 gigapixels can be [seen here](https://easyzoom
 
 1. Have Noita installed.
 2. Download the [latest release of the mod from this link](https://github.com/Dadido3/noita-mapcap/releases/latest) (The `Windows.x86.7z`, not the source)
-3. Unpack it into your mods folder, so that you get the following file structure `.../Noita/mods/noita-mapcap/mod.xml`.
-4. Set your resolution to 1280x720, and use the `Windowed` mode. (Not `Fullscreen (Windowed)`!) If you have to use a different resolution, see [Advanced stuff](#advanced-stuff).
-5. Enable the mod and restart Noita.
-6. In the game you should see text on screen.
+3. Unpack it into your `mods` folder, so that you get the following file structure `./Noita/mods/noita-mapcap/mod.xml`.
+4. Run `Apply-Settings.ps1` with [PowerShell 7](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.2) to automatically configure noita_dev.exe and its config. If you have a 1440p monitor, rename `settings.1440.jsonc` to `settings.jsonc`.
+5. If you used `Apply-Settings.ps1`, skip step 6 and 7.
+6. Set your resolution to 1280x720, and use the `Windowed` mode. (Not `Fullscreen (Windowed)`!) If you have to use a different resolution, see [Advanced stuff](#advanced-stuff).
+7. Enable the mod and restart Noita.
+8. In the game you should see text on screen.
     - Either press `>> Start capturing map around view <<` to capture in a spiral around your current view.
     - Or press any other option to capture [specific areas](AREAS.md).
-7. The screen will jump around, and the game will take screenshots automatically.
+9. The screen will jump around, and the game will take screenshots automatically.
     - Screenshots are saved in `.../Noita/mods/noita-mapcap/output/`.
     - Don't move the game window outside of screen space. You can cover it with other windows, and continue using your PC.
     - Don't minimize the game window.
     - If you need to pause, use the ESC menu.
     - Also, make sure that the console window isn't selected, as you will end up with screenshots of the console instead of the game. You can select and use any other window while it's capturing screenshots, though.
     - Noita may crash in the process or show error messages. If you encounter an `ASSERT FAILED!` message click on `Ignore always`. If Noita crashes you can restart it, load your save and start capturing again. It will continue from where it stopped. More information/details about this can be found [here](https://github.com/Dadido3/noita-mapcap/issues/7#issuecomment-723571110).
-8. When you think you are done, close Noita.
-9. Start `.../Noita/mods/noita-mapcap/bin/stitch/stitch.exe`.
+10. When you think you are done, close Noita.
+11. Start `.../Noita/mods/noita-mapcap/bin/stitch/stitch.exe`.
     - Use the default values to create a complete stitch.
     - It will take the screenshots from the `output` folder.
-10. The result will be saved as `.../Noita/mods/noita-mapcap/bin/stitch/output.png` if not defined otherwise.
+12. The result will be saved as `.../Noita/mods/noita-mapcap/bin/stitch/output.png` if not defined otherwise.
 
 ## How to do a full map capture with minimal trouble
 

--- a/settings.1440p.jsonc
+++ b/settings.1440p.jsonc
@@ -1,0 +1,9 @@
+{
+    "general_settings": {
+        "CAPTURE_RESOLUTION_WIDTH": 1024,  // REQUIRED! Note: this setting overwrites window_w, internal_size_w, backbuffer_width
+        "CAPTURE_RESOLUTION_HEIGHT": 1024, // REQUIRED! Note: this setting overwrites window_h, internal_size_h, backbuffer_height
+        "CAPTURE_GRID_SIZE": 1024,         // OPTIONAL. Note: Adjust the capture grid size. Must fit into an area of CAPTURE_RESOLUTION_HEIGHT * CAPTURE_RESOLUTION_WIDTH
+        "WORLD_SEED": 119984861            // OPTIONAL. Note: Set the seed of the world you want to capture, or set it to null for random worlds.
+    },
+    "config_xml": { }
+}

--- a/settings.default.jsonc
+++ b/settings.default.jsonc
@@ -1,0 +1,20 @@
+{
+    "general_settings": {
+        "CAPTURE_RESOLUTION_WIDTH": 1280, // REQUIRED! Note: this setting overwrites window_w, internal_size_w, backbuffer_width
+        "CAPTURE_RESOLUTION_HEIGHT": 768, // REQUIRED! Note: this setting overwrites window_h, internal_size_h, backbuffer_height
+        "CAPTURE_GRID_SIZE": 512,         // OPTIONAL. Note: Adjust the capture grid size. Must fit into an area of CAPTURE_RESOLUTION_HEIGHT * CAPTURE_RESOLUTION_WIDTH
+        "WORLD_SEED": null                // OPTIONAL. Note: Set the seed of the world you want to capture, or set it to null for random worlds.
+    },
+    "config_xml": {
+        "audio_effects_volume": 0.2,
+        "audio_music_volume": 0,
+        "has_been_started_before": 1,
+        "mods_disclaimer_accepted": 1,
+        "mods_sandbox_enabled": 0,
+        "mods_sandbox_warning_done": 1,
+        "online_features": 0,
+        "rendering_filmgrain": 0,
+        "rendering_pixel_art_antialiasing": 0,
+        "screenshake_intensity": 0
+    }
+}


### PR DESCRIPTION
@Dadido3 this is the pull request for the settings feature. It just needs one more thing to properly work, which is that in capture.lua the `CAPTURE_GRID_SIZE` should be read from `settings.jsonc` if the file exists, otherwise read it from `settings.default.jsonc`.